### PR TITLE
Add basic support for multiple Nvidia GPUs

### DIFF
--- a/LLMcalc.py
+++ b/LLMcalc.py
@@ -247,7 +247,10 @@ def get_vram_specs():
         try:
             try:
                 cmd = ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"]
-                vram = float(subprocess.check_output(cmd).decode().strip()) / 1024
+                output = subprocess.check_output(cmd).decode().strip()
+                lines = output.splitlines()
+                vrams = [float(line.strip()) for line in lines if line.strip() != ""]
+                vram = (sum(vrams) / len(vrams)) / 1024
             except:
                 pass
 


### PR DESCRIPTION
The current logic for gathering vram from Nvidia GPUs only works if there is a single GPU. If there are multiple Nvidia GPUs nvidia-smi returns the vram for each GPU on a seperate line. This change adds the ability to support multiple nvidia gpus by taking the average vram from the available GPUs. The user still needs to manually set the number of GPUs, but this change at least prevents the application from crashing on launch.